### PR TITLE
[FIX] account: When creating invoice, system removes 'invoice_line_ids'

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1672,7 +1672,7 @@ class AccountMove(models.Model):
 
             is_invoice = vals.get('type') in self.get_invoice_types(include_receipts=True)
 
-            if 'line_ids' in vals:
+            if vals.get('line_ids'):
                 vals.pop('invoice_line_ids', None)
                 new_vals_list.append(vals)
                 continue


### PR DESCRIPTION
Before this commit:

When Creating Invoice (i.e. from Repair Order), Invoice Lines will not be created.

After this commit:

Invoice with proper Invoice Lines will be created.